### PR TITLE
Sudo was deprecated on version 1.9.

### DIFF
--- a/vagrant_ansible_examples/nfs_ruby1.9.3_mysql/playbook.yml
+++ b/vagrant_ansible_examples/nfs_ruby1.9.3_mysql/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
-  sudo: true
+  become: yes
+  become_method: sudo
   vars:
     document_root: /your_app_name
   pre_tasks:

--- a/vagrant_ansible_examples/nfs_ruby2.2.3_mysql_xfce_chrome/playbook.yml
+++ b/vagrant_ansible_examples/nfs_ruby2.2.3_mysql_xfce_chrome/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
-  sudo: true
+  become: yes
+  become_method: sudo
   vars:
     document_root: /your_app_name
     apt_file: /etc/apt/sources.list.d/google-chrome.list

--- a/vagrant_ansible_examples/php_mysql_apache/playbook.yml
+++ b/vagrant_ansible_examples/php_mysql_apache/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
-  sudo: true
+  become: yes
+  become_method: sudo
   vars:
     document_root: /vagrant
   pre_tasks:


### PR DESCRIPTION
On Ansible 1.9, **sudo** option was deprecated by **become** and now is the preferred method.